### PR TITLE
Add AxiosErrorMixin

### DIFF
--- a/src/__tests__/mixins/__snapshots__/axiosError.test.ts.snap
+++ b/src/__tests__/mixins/__snapshots__/axiosError.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AxiosErrorMixin handleError throw AxiosError based on input [Error: foo bar issue] 1`] = `[AxiosError: foo bar issue]`;
+
+exports[`AxiosErrorMixin handleError throw AxiosError based on input {"config": [Object], "data": [Object], "headers": [Object], "status": 400, "statusText": "Bad Request"} 1`] = `[AxiosError: An unexpected error has occurred. Please try again.]`;
+
+exports[`AxiosErrorMixin handleError throw AxiosError based on input {"config": [Object], "data": [Object], "headers": [Object], "status": 422, "statusText": "Unprocessable Entity"} 1`] = `[AxiosError: hello foo bar]`;
+
+exports[`AxiosErrorMixin handleError throw AxiosError based on input {"data": [Object]} 1`] = `[AxiosError: An unexpected error has occurred. Please try again.]`;
+
+exports[`AxiosErrorMixin handleError throw AxiosError based on input {"data": undefined} 1`] = `[AxiosError: An unexpected error has occurred. Please try again.]`;
+
+exports[`AxiosErrorMixin handleError throw AxiosError based on input undefined 1`] = `[AxiosError]`;

--- a/src/__tests__/mixins/axiosError.test.ts
+++ b/src/__tests__/mixins/axiosError.test.ts
@@ -1,0 +1,55 @@
+import axios, { AxiosError, AxiosResponse } from 'axios'
+import { AxiosErrorMixin } from '../../mixins'
+import { Endpoint } from '../../endpoint'
+import { BasicMock } from '../mock/axios'
+
+jest.spyOn(axios, 'request').mockImplementation(BasicMock)
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+jest.spyOn(global.console, 'log').mockImplementation(() => {})
+
+class TestEndpoint extends AxiosErrorMixin(Endpoint) {}
+
+const response = {
+  config: {},
+  status: 422,
+  statusText: 'Unprocessable Entity',
+  headers: {},
+  data: {},
+}
+
+type TransformInput = (axiosResponse?: Partial<AxiosResponse>) => AxiosError
+
+const noTransform = (input: any): any => input
+
+const makeAxiosError: TransformInput = (axiosResponse?: Partial<AxiosResponse>): AxiosError => {
+  const err = new AxiosError()
+  if (response) {
+    err.response = {
+      data: undefined,
+      status: 500,
+      statusText: 'Testing',
+      headers: {},
+      config: {},
+      ...axiosResponse,
+    }
+  }
+  return err
+}
+
+describe(`${AxiosErrorMixin.name}`, (): void => {
+  it.each([
+    [undefined, noTransform],
+    [new Error('foo bar issue'), noTransform],
+    [{ data: undefined }, makeAxiosError],
+    [{ data: { errors: { key: [] } } }, makeAxiosError],
+    [{ ...response, data: { message: 'hello foo bar' } }, makeAxiosError],
+    [{ ...response, status: 400, statusText: 'Bad Request' }, makeAxiosError],
+  ])(
+    'handleError throw AxiosError based on input %p',
+    async (error: any, transform: TransformInput): Promise<void> => {
+      expect.assertions(1)
+      const expectThrow = async (): Promise<never> => new TestEndpoint().handleError(transform(error))
+      await expect(expectThrow()).rejects.toMatchSnapshot()
+    },
+  )
+})

--- a/src/mixins/axiosError.ts
+++ b/src/mixins/axiosError.ts
@@ -1,0 +1,53 @@
+import { Constructor } from './types'
+import axios, { AxiosError } from 'axios'
+import { safeResponseData } from '../helpers'
+import { defaultErrorMessage as constDefaultErrorMessage, errorsBlock as baseErrorsBlock } from './helpers'
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function AxiosErrorMixin<T extends Constructor<any>>(superClass: T) {
+  return class extends superClass {
+    get defaultErrorMessage(): string {
+      return constDefaultErrorMessage
+    }
+
+    errorsBlock(message: string): { message: string } {
+      return baseErrorsBlock(message)
+    }
+
+    handleError(error: AxiosError | Error): never {
+      let message = this.defaultErrorMessage
+      if (!axios.isAxiosError(error)) {
+        const axiosErr = new AxiosError(error.message)
+        axiosErr.response = {
+          headers: {},
+          config: {},
+          status: 500,
+          statusText: 'Internal Server Error',
+          data: {
+            message,
+            errors: this.errorsBlock(message),
+          },
+        }
+        throw axiosErr
+      }
+      const { errors, message: responseMessage } = safeResponseData<Record<string, unknown>>(error.response)
+      // Matches what we want from our response.
+      if (errors && typeof errors === 'object') {
+        throw error
+      } else if (typeof responseMessage === 'string') {
+        message = responseMessage
+      }
+      error.response = {
+        headers: error?.response?.headers ?? {},
+        config: error?.config ?? error?.response?.config,
+        status: error?.response?.status ?? 500,
+        statusText: error?.response?.statusText ?? 'Internal Server Error',
+        data: {
+          message,
+          errors: this.errorsBlock(message),
+        },
+      }
+      throw error
+    }
+  }
+}

--- a/src/mixins/axiosError.ts
+++ b/src/mixins/axiosError.ts
@@ -17,7 +17,7 @@ export function AxiosErrorMixin<T extends Constructor<any>>(superClass: T) {
     handleError(error: AxiosError | Error): never {
       let message = this.defaultErrorMessage
       if (!axios.isAxiosError(error)) {
-        const axiosErr = new AxiosError(error.message)
+        const axiosErr = new AxiosError(error?.message)
         axiosErr.response = {
           headers: {},
           config: {},
@@ -31,11 +31,14 @@ export function AxiosErrorMixin<T extends Constructor<any>>(superClass: T) {
         throw axiosErr
       }
       const { errors, message: responseMessage } = safeResponseData<Record<string, unknown>>(error.response)
-      // Matches what we want from our response.
+      if (typeof responseMessage === 'string') {
+        message = responseMessage
+      }
+      if (!error.message) {
+        error.message = message
+      }
       if (errors && typeof errors === 'object') {
         throw error
-      } else if (typeof responseMessage === 'string') {
-        message = responseMessage
       }
       error.response = {
         headers: error?.response?.headers ?? {},

--- a/src/mixins/handleError.ts
+++ b/src/mixins/handleError.ts
@@ -1,5 +1,6 @@
 import { AxiosError, AxiosResponse } from 'axios'
 import { Constructor } from './types'
+import { defaultErrorMessage as constDefaultErrorMessage, errorsBlock as baseErrorsBlock } from './helpers'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function HandleErrorMixin<T extends Constructor<any>>(superClass: T) {
@@ -12,13 +13,11 @@ export function HandleErrorMixin<T extends Constructor<any>>(superClass: T) {
     }
 
     get defaultErrorMessage(): string {
-      return 'An unexpected error has occurred. Please try again.'
+      return constDefaultErrorMessage
     }
 
-    errorsBlock(message: string): any {
-      return {
-        message,
-      }
+    errorsBlock(message: string): { message: string } {
+      return baseErrorsBlock(message)
     }
 
     handleError<T = any>(error: AxiosError<T> | any): AxiosResponse<T | { message?: string; errors: any }> {

--- a/src/mixins/helpers.ts
+++ b/src/mixins/helpers.ts
@@ -1,0 +1,3 @@
+export const defaultErrorMessage = 'An unexpected error has occurred. Please try again.'
+
+export const errorsBlock = (message: string): { message: string } => ({ message })

--- a/src/mixins/index.ts
+++ b/src/mixins/index.ts
@@ -1,5 +1,6 @@
 export * from './api'
 export * from './auth'
+export * from './axiosError'
 export * from './form'
 export * from './handleApi'
 export * from './handleError'


### PR DESCRIPTION
This mixin can be used with `react-query` or just to make sure that an instance of `AxiosError` is returned with the expected `response` format.